### PR TITLE
Add support for throws

### DIFF
--- a/README.md
+++ b/README.md
@@ -26,5 +26,6 @@ Use [bem-jsd](https://github.com/bem/bem-jsd) for fancy API.
   * @readonly
   * @returns
   * @see
+  * @throws
   * @type
   * @version

--- a/plugins/throws.js
+++ b/plugins/throws.js
@@ -1,0 +1,18 @@
+module.exports = function(jsdoc) {
+    jsdoc
+        .registerParser('throws', function(comment) {
+            var match = comment.match(/^(?:{([^}]+)}\s*)?(.*?)\s*$/);
+
+            return {
+                jsType : require('./util/js-type').parse(match[1]),
+                description : match[2]
+            };
+        })
+        .registerBuilder('throws', function(tag, curJsdocNode) {
+            curJsdocNode.throws = {
+                jsdocType : 'throws',
+                description : tag.description,
+                jsType : tag.jsType
+            }
+        });
+};

--- a/test/_util/index.js
+++ b/test/_util/index.js
@@ -28,6 +28,7 @@ exports.testPlugins = function(testFile) {
             'license',
             'copyright',
             'see',
+            'throws',
             'readonly',
             require('jsd/plugins/description')
         ].map(function(plugin) {

--- a/test/throws.js
+++ b/test/throws.js
@@ -1,0 +1,3 @@
+var U = require('./_util');
+
+U.testPlugins(__filename);

--- a/test/throws/throws.js
+++ b/test/throws/throws.js
@@ -1,0 +1,17 @@
+/**
+ * @module my-module
+ */
+
+modules.define('my-module', function(provide) {
+
+provide(/** @exports my-module */{
+    /**
+     * Description of method1
+     * @throws {Error} some description
+     */
+    method1 : function() {
+
+    }
+});
+
+});

--- a/test/throws/throws.json
+++ b/test/throws/throws.json
@@ -1,0 +1,28 @@
+{
+    "jsdocType": "root",
+    "modules": [
+        {
+            "jsdocType": "module",
+            "name": "my-module",
+            "exports": {
+                "jsdocType": "type",
+                "jsType": "Object",
+                "props": [
+                    {
+                        "key": "method1",
+                        "val": {
+                            "jsdocType": "type",
+                            "jsType": "Function",
+                            "description": "Description of method1",
+                            "throws": {
+                                "jsdocType" : "throws",
+                                "description" : "some description",
+                                "jsType" : "Error"
+                            }
+                        }
+                    }
+                ]
+            }
+        }
+    ]
+}


### PR DESCRIPTION
But why such basic jsdoc tags support provided by `jsd-plugins-bem`?